### PR TITLE
fix ruamel.yaml on 0.14.X for now

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ruamel.yaml!=0.14.7
+ruamel.yaml!=0.14.7,<0.15
 colorama
 argcomplete


### PR DESCRIPTION
Thank you for using ruamel.yaml.

There will be API changes in the 0.15+ versions, that might lead to warnings that 
your user could see.
Therefore please release a version of your package with this change, so that it will not
automatically take the latest ruamel.yaml release.
